### PR TITLE
Relax upper bounds on data-default & transformers for ghc-8

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,13 @@
-# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.11
+resolver: nightly-2016-05-26
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- wai-session-0.3.2
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}
@@ -22,7 +20,7 @@ extra-package-dbs: []
 
 # Require a specific version of stack, using version ranges
 # require-stack-version: -any # Default
-# require-stack-version: >= 0.1.4.0
+# require-stack-version: >= 1.0.0
 
 # Override the architecture used by stack, especially useful on Windows
 # arch: i386
@@ -31,3 +29,6 @@ extra-package-dbs: []
 # Extra directories used by stack for building
 # extra-include-dirs: [/path/to/dir]
 # extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor

--- a/wai-session-postgresql.cabal
+++ b/wai-session-postgresql.cabal
@@ -23,13 +23,13 @@ library
                      , bytestring >= 0.10.0.2 && < 0.11
                      , cereal >= 0.4.1 && < 0.6
                      , cookie >= 0.4.1 && < 0.5
-                     , data-default >= 0.5.1 && < 0.7
+                     , data-default >= 0.5.1 && < 0.8
                      , entropy >= 0.3 && < 0.4
                      , postgresql-simple >= 0.4.0 && < 0.6
                      , resource-pool >= 0.2.3 && < 0.3
                      , text >= 0.11.3.1 && < 1.3
                      , time >= 1.4.0.1 && < 1.7
-                     , transformers >= 0.3.0 && < 0.5
+                     , transformers >= 0.3.0 && < 0.6
                      , wai >= 3.0.2.3 && < 3.3
                      , wai-session >= 0.3.2 && < 0.4
   default-language:    Haskell2010
@@ -41,7 +41,7 @@ test-suite postgresql-session-test
   main-is:             Spec.hs
   build-depends:       base
                      , bytestring >= 0.10.0.2 && < 0.11
-                     , data-default >= 0.5.1 && < 0.6
+                     , data-default >= 0.5.1 && < 0.8
                      , postgresql-simple >= 0.4.0 && < 0.6
                      , text >= 0.11.3.1 && < 1.3
                      , wai-session >= 0.3.2 && < 0.4


### PR DESCRIPTION
Update stackage snapshot to nightly-2016-05-26

Fixes #1 
