### PR TITLE
Fix concurrency bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 Provides a PostgreSQL based session store for Network.Wai.Session.
 
 See example/Main.hs for an example usage.
+
+
+For running the test you need:
+
+```
+sudo -u postgres createuser demo
+sudo -u postgres psql -c "ALTER USER demo WITH PASSWORD 'omed'"
+sudo -u postgres createdb -Odemo demodb
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/hce/postgresql-session.svg?branch=master)](https://travis-ci.org/hce/postgresql-session)
 
-Provides a PostgreSQL based session store for Network.Wai.Session.
+Provides a PostgreSQL (9.5 or later) based session store for Network.Wai.Session.
 
 See example/Main.hs for an example usage.
 

--- a/src/Network/Wai/Session/PostgreSQL.hs
+++ b/src/Network/Wai/Session/PostgreSQL.hs
@@ -130,9 +130,6 @@ qryCreateSession        = "INSERT INTO wai_pg_sessions (session_key, session_cre
 qryCreateSessionEntry :: Query
 qryCreateSessionEntry   = "INSERT INTO wai_pg_session_data (wai_pg_session,key,value) VALUES (?,?,?)"
 
-qryUpdateSession       :: Query
-qryUpdateSession        = "UPDATE wai_pg_sessions SET session_last_access=? WHERE id=?"
-
 qryUpdateSessionEntry  :: Query
 qryUpdateSessionEntry   = "UPDATE wai_pg_session_data SET value=? WHERE wai_pg_session=? AND key=?"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,6 +24,10 @@ spec = describe "Network.Wai.Session.PostgreSQL" $ it "handles sessions" $ do
     sessid <- mknewsessid
 
     -- insert
+    insertSess1 ("foo" :: B.ByteString) ("foo" :: B.ByteString)
+    lookupSess1 "foo" `shouldReturn` Just "foo"
+
+    -- update
     insertSess1 ("foo" :: B.ByteString) ("bar" :: B.ByteString)
     lookupSess1 "foo" `shouldReturn` Just "bar"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,15 +19,18 @@ spec = describe "Network.Wai.Session.PostgreSQL" $ it "handles sessions" $ do
     store <- dbStore conn' testSettings
     purger conn' testSettings
 
+    -- new session
     ((lookupSess1, insertSess1), mknewsessid) <- store Nothing
     sessid <- mknewsessid
 
+    -- insert
     insertSess1 ("foo" :: B.ByteString) ("bar" :: B.ByteString)
-
     lookupSess1 "foo" `shouldReturn` Just "bar"
 
+    -- non-existing key
     lookupSess1 "bar" `shouldReturn` Nothing
 
+    -- existing session
     ((lookupSess2, insertSess2), mknewsessid) <- store $ Just sessid
     newsessid <- mknewsessid
 
@@ -35,6 +38,7 @@ spec = describe "Network.Wai.Session.PostgreSQL" $ it "handles sessions" $ do
 
     newsessid `shouldBe` sessid
 
+    -- invalid session
     let invalidsessid = "foobar"
     ((lookupSess3, insertSess3), mknewsessid) <- store $ Just invalidsessid
     newsessid2 <- mknewsessid
@@ -44,11 +48,12 @@ spec = describe "Network.Wai.Session.PostgreSQL" $ it "handles sessions" $ do
 
     lookupSess3 "foo" `shouldReturn` Nothing
 
+    -- re-accessing session
     ((lookupSess4, insertSess4), mknewsessid) <- store $ Just sessid
     lookupSess4 "foo" `shouldReturn` Just "bar"
 
+    -- purged session
     threadDelay 2000000
-
     ((lookupSess5, insertSess5), mknewsessid) <- store $ Just sessid
     lookupSess5 "foo" `shouldReturn` Nothing
 

--- a/wai-session-postgresql.cabal
+++ b/wai-session-postgresql.cabal
@@ -46,6 +46,7 @@ test-suite postgresql-session-test
                      , text
                      , wai-session
                      , wai-session-postgresql
+                     , hspec
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
Steps to reproduce:

```
module Main where

import Data.Default (def)
import Database.PostgreSQL.Simple
import Network.Wai.Session.PostgreSQL
import Control.Concurrent.Async
import Control.Monad
import Data.Pool

main :: IO ()
main = do
    pool <- createPool dbconnect close 1 10 5
    forever $ do
        store <- dbStore pool testSettings
        (_, mknewsessid) <- store Nothing
        sessid <- mknewsessid
        threads <- replicateM 5 $ async $ do
            ((_, insertSess), _) <- store $ Just sessid
            insertSess ("foo" :: String) ("bar" :: String)
        mapM_ wait threads

dbconnect :: IO Connection
dbconnect = do
    let connectInfo = ConnectInfo {
          connectHost = "localhost"
        , connectPort = 5432
        , connectUser = "demo"
        , connectPassword = "omed"
        , connectDatabase = "demodb" }
    connectPostgreSQL $ postgreSQLConnectionString connectInfo

testSettings :: StoreSettings
testSettings = def { storeSettingsSessionTimeout=1 }
```
